### PR TITLE
this never link against Boost_LIBRARIES, this means we dont need all …

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -42,7 +42,7 @@
     <depend>binutils</depend>
     <depend>libqt5-svg-dev</depend>
     <depend>libqt5-websockets-dev</depend>
-    <depend>boost</depend>
+    <depend>libboost-dev</depend>
 
     <!-- The export tag contains other, unspecified, tags -->
     <export>


### PR DESCRIPTION
As we dont link against any of the boost libraries, we can just use the header-only parts of Boost that are provided by the libboost-dev package. This reduces the amount of libraries to download by ~500MB