### PR TITLE
[ROS2] sum sec and nanosec*1e-9 in stamp for all messages + use quaternion parser of tf

### DIFF
--- a/plugins/ros2_parsers/imu_msg.h
+++ b/plugins/ros2_parsers/imu_msg.h
@@ -16,8 +16,7 @@ public:
     , _lin_acc_covariance(topic_name + "/linear_acceleration_covariance", plot_data)
     , _ang_vel_covariance(topic_name + "/angular_velocity_covariance", plot_data)
   {
-    _data.push_back(&getSeries(topic_name + "/header/stamp/sec"));
-    _data.push_back(&getSeries(topic_name + "/header/stamp/nanosec"));
+    _data.push_back(&getSeries(topic_name + "/header/stamp"));
 
     _data.push_back(&getSeries(topic_name + "/angular_velocity/x"));
     _data.push_back(&getSeries(topic_name + "/angular_velocity/y"));
@@ -30,20 +29,20 @@ public:
 
   void parseMessageImpl(const sensor_msgs::msg::Imu& msg, double& timestamp) override
   {
+    double header_stamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
     if (_use_header_stamp)
     {
-      timestamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
+      timestamp = header_stamp;
     }
-    _data[0]->pushBack({ timestamp, double(msg.header.stamp.sec) });
-    _data[1]->pushBack({ timestamp, double(msg.header.stamp.sec) });
+    _data[0]->pushBack({ timestamp, header_stamp });
 
-    _data[2]->pushBack({ timestamp, msg.angular_velocity.x });
-    _data[3]->pushBack({ timestamp, msg.angular_velocity.y });
-    _data[4]->pushBack({ timestamp, msg.angular_velocity.z });
+    _data[1]->pushBack({ timestamp, msg.angular_velocity.x });
+    _data[2]->pushBack({ timestamp, msg.angular_velocity.y });
+    _data[3]->pushBack({ timestamp, msg.angular_velocity.z });
 
-    _data[5]->pushBack({ timestamp, msg.linear_acceleration.x });
-    _data[6]->pushBack({ timestamp, msg.linear_acceleration.y });
-    _data[7]->pushBack({ timestamp, msg.linear_acceleration.z });
+    _data[4]->pushBack({ timestamp, msg.linear_acceleration.x });
+    _data[5]->pushBack({ timestamp, msg.linear_acceleration.y });
+    _data[6]->pushBack({ timestamp, msg.linear_acceleration.z });
 
     _quat_parser.parseMessageImpl(msg.orientation, timestamp);
 

--- a/plugins/ros2_parsers/jointstates_msg.h
+++ b/plugins/ros2_parsers/jointstates_msg.h
@@ -9,19 +9,18 @@ public:
   JointStateMsgParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data)
     : BuiltinMessageParser<sensor_msgs::msg::JointState>(topic_name, plot_data)
   {
-    _data.push_back(&getSeries(topic_name + "/header/stamp/sec"));
-    _data.push_back(&getSeries(topic_name + "/header/stamp/nanosec"));
+    _data.push_back(&getSeries(topic_name + "/header/stamp"));
   }
 
   void parseMessageImpl(const sensor_msgs::msg::JointState& msg, double& timestamp) override
   {
+    double header_stamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
     if (_use_header_stamp)
     {
-      timestamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
+      timestamp = header_stamp;
     }
 
-    _data[0]->pushBack({ timestamp, double(msg.header.stamp.sec) });
-    _data[1]->pushBack({ timestamp, double(msg.header.stamp.nanosec) });
+    _data[0]->pushBack({ timestamp, header_stamp });
 
     for (int i = 0; i < msg.name.size(); i++)
     {

--- a/plugins/ros2_parsers/odometry_msg.h
+++ b/plugins/ros2_parsers/odometry_msg.h
@@ -13,19 +13,18 @@ public:
     , _pose_parser(topic_name + "/pose", plot_data)
     , _twist_parser(topic_name + "/twist", plot_data)
   {
-    _data.push_back(&getSeries(topic_name + "/header/stamp/sec"));
-    _data.push_back(&getSeries(topic_name + "/header/stamp/nanosec"));
+    _data.push_back(&getSeries(topic_name + "/header/stamp"));
   }
 
   void parseMessageImpl(const nav_msgs::msg::Odometry& msg, double& timestamp) override
   {
+    double header_stamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
     if (_use_header_stamp)
     {
-      timestamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
+      timestamp = header_stamp;
     }
 
-    _data[0]->pushBack({ timestamp, double(msg.header.stamp.sec) });
-    _data[1]->pushBack({ timestamp, double(msg.header.stamp.nanosec) });
+    _data[0]->pushBack({ timestamp, header_stamp });
 
     _pose_parser.parseMessageImpl(msg.pose, timestamp);
     _twist_parser.parseMessageImpl(msg.twist, timestamp);

--- a/plugins/ros2_parsers/pose_msg.h
+++ b/plugins/ros2_parsers/pose_msg.h
@@ -39,18 +39,17 @@ public:
   PoseStampedMsgParser(const std::string& topic_name, PJ::PlotDataMapRef& plot_data)
     : BuiltinMessageParser<geometry_msgs::msg::PoseStamped>(topic_name, plot_data), _pose_parser(topic_name, plot_data)
   {
-    _data.push_back(&getSeries(topic_name + "/header/stamp/sec"));
-    _data.push_back(&getSeries(topic_name + "/header/stamp/nanosec"));
+    _data.push_back(&getSeries(topic_name + "/header/stamp"));
   }
 
   void parseMessageImpl(const geometry_msgs::msg::PoseStamped& msg, double& timestamp) override
   {
+    double header_stamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
     if (_use_header_stamp)
     {
-      timestamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
+      timestamp = header_stamp;
     }
-    _data[0]->pushBack({ timestamp, double(msg.header.stamp.sec) });
-    _data[1]->pushBack({ timestamp, double(msg.header.stamp.nanosec) });
+    _data[0]->pushBack({ timestamp, header_stamp });
 
     _pose_parser.parseMessageImpl(msg.pose, timestamp);
   }

--- a/plugins/ros2_parsers/tf_msg.h
+++ b/plugins/ros2_parsers/tf_msg.h
@@ -44,20 +44,10 @@ public:
       series = &getSeries( prefix + "/translation/z");
       series->pushBack({ timestamp, trans.transform.translation.z });
 
-      series = &getSeries( prefix + "/rotation/x");
-      series->pushBack({ timestamp, trans.transform.rotation.x });
-
-      series = &getSeries( prefix + "/rotation/y");
-      series->pushBack({ timestamp, trans.transform.rotation.y });
-
-      series = &getSeries( prefix + "/rotation/z");
-      series->pushBack({ timestamp, trans.transform.rotation.z });
-
-      series = &getSeries( prefix + "/rotation/w");
-      series->pushBack({ timestamp, trans.transform.rotation.w });
+      QuaternionMsgParser quat_parser(prefix + "/rotation", this->plotData());
+      quat_parser.parseMessageImpl(trans.transform.rotation, timestamp);
     }
   }
 private:
-
 };
 

--- a/plugins/ros2_parsers/twist_msg.h
+++ b/plugins/ros2_parsers/twist_msg.h
@@ -43,19 +43,18 @@ public:
     : BuiltinMessageParser<geometry_msgs::msg::TwistStamped>(topic_name, plot_data)
     , _twist_parser(topic_name, plot_data)
   {
-    _data.push_back(&getSeries(topic_name + "/header/stamp/sec"));
-    _data.push_back(&getSeries(topic_name + "/header/stamp/nanosec"));
+    _data.push_back(&getSeries(topic_name + "/header/stamp"));
   }
 
   void parseMessageImpl(const geometry_msgs::msg::TwistStamped& msg, double& timestamp) override
   {
+    double header_stamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
     if (_use_header_stamp)
     {
-      timestamp = double(msg.header.stamp.sec) + double(msg.header.stamp.nanosec) * 1e-9;
+      timestamp = header_stamp;
     }
 
-    _data[0]->pushBack({ timestamp, double(msg.header.stamp.sec) });
-    _data[1]->pushBack({ timestamp, double(msg.header.stamp.nanosec) });
+    _data[0]->pushBack({ timestamp, header_stamp });
 
     _twist_parser.parseMessageImpl(msg.twist, timestamp);
   }


### PR DESCRIPTION
Only the tf parser was summing the sec and nanosec*1e-9 of the header stamp (which is much more convenient to exploit in plotjuggler). This PR extends this approach in imu, jointstate, odometry, pose and twist msgs using a similar method.
But it also does it for all other msgs having a "header/stamp" through the ros2_parser (though the implementation is maybe not the most optimal, we can discuss it).
While I was at it (looking at the parsers), I modifed the tf parser to use the quaternion parser for its rotation (as it is done for the pose orientation) in order to have direct access to pitch_deg, roll_deg and yaw_deg.