### PR TITLE
Keep multiple bags in memory

### DIFF
--- a/plugins/DataLoadROS/dataload_ros.cpp
+++ b/plugins/DataLoadROS/dataload_ros.cpp
@@ -145,12 +145,12 @@ bool DataLoadROS::readDataFromFile(PJ::FileLoadInfo* info, PJ::PlotDataMapRef& p
 
   //--- Swith the previous bag with this one
   // clean up previous MessageInstances
-  plot_map.user_defined.clear();
-  if (_bag)
-  {
-    _bag->close();
-  }
-  _bag = temp_bag;
+  //plot_map.user_defined.clear();
+  //if (_bag)
+  //{
+  //  _bag->close();
+  //}
+  _bags.push_back(temp_bag);
   //---------------------------------------
 
   saveDefaultSettings();
@@ -175,7 +175,7 @@ bool DataLoadROS::readDataFromFile(PJ::FileLoadInfo* info, PJ::PlotDataMapRef& p
   progress_dialog.setLabelText("Loading... please wait");
   progress_dialog.setWindowModality(Qt::ApplicationModal);
 
-  rosbag::View bag_view(*_bag);
+  rosbag::View bag_view(*_bags.back());
 
   progress_dialog.setRange(0, bag_view.size() - 1);
   progress_dialog.show();

--- a/plugins/DataLoadROS/dataload_ros.h
+++ b/plugins/DataLoadROS/dataload_ros.h
@@ -40,7 +40,7 @@ public:
 protected:
   void loadSubstitutionRule(QStringList all_topic_names);
 
-  std::shared_ptr<rosbag::Bag> _bag;
+  std::vector<std::shared_ptr<rosbag::Bag>> _bags;
 
 private:
   std::vector<const char*> _extensions;


### PR DESCRIPTION
Keep every Bag instance in memory.

This fixes a crash when loading multiple bags and trying to replay them.

Ideally, we would want to keep the bags only if the user wants to keep the old data but that is not something the plugin is aware of.

Requires facontidavide/PlotJuggler#485 to fully enable the publication of messages from multiple bags.