### PR TITLE
parse comma-separated doubles from diagnosticArray key-values.

### DIFF
--- a/plugins/ros1_parsers/diagnostic_msg.h
+++ b/plugins/ros1_parsers/diagnostic_msg.h
@@ -27,7 +27,7 @@ public:
       for (const auto& kv : status.values)
       {
         const char* start_ptr = kv.value.data();
-        double val = 0;
+        std::vector<double> val;
 
         if (status.hardware_id.empty())
         {
@@ -38,12 +38,21 @@ public:
           key = fmt::format("{}/{}/{}/{}", _topic_name, status.hardware_id, status.name, kv.key);
         }
 
-        bool parsed = boost::spirit::qi::parse(start_ptr, start_ptr + kv.value.size(),
-                                               boost::spirit::qi::double_, val);
-        if (parsed)
+        bool parsed = boost::spirit::qi::phrase_parse(start_ptr, start_ptr + kv.value.size(),
+                                               boost::spirit::qi::double_ % ',', boost::spirit::qi::ascii::space, val);
+        if (val.size() > 1)
         {
-          auto& series = getSeries(key);
-          series.pushBack({ timestamp, val });
+          for (size_t index = 0; index < val.size(); index++)
+          {
+            std::string subkey = fmt::format("{}/{}", key, index);
+            auto& series = getSeries(subkey);
+            series.pushBack({ timestamp, val[index] });  
+          }
+        }
+        else if (parsed)
+        {
+            auto& series = getSeries(key);
+            series.pushBack({ timestamp, val[0] });  
         }
         else{
           auto& series = getStringSeries(key);


### PR DESCRIPTION
Currently when using diagnostics message for plotting, the values in key-value pair are parsed as a single double. I am currently working on a project, where multiple comma separated double values are published in diagnostics (for example "acceleration": "x,y,z"), because they are more compact to view from runtime diagnostics in this form. Sometimes I would also like to plot these diagnostic values, but only seeing the first value is not sufficient, I would like to see other values as well. Would parsing the string as a comma-separated list of doubles be ok?