### PR TITLE
fix implicit uint8_t -> double narrowing

### DIFF
--- a/plugins/ros1_parsers/fiveai_stamped_diagnostic.h
+++ b/plugins/ros1_parsers/fiveai_stamped_diagnostic.h
@@ -100,7 +100,7 @@ class FiveAiDiagnosticMsg : public RosMessageParser
       {
         auto key = fmt::format("{}/{}/status", _topic_name, replaced_key);
         auto& series = getSeries(key);
-        series.pushBack({ timestamp, diag.status });
+        series.pushBack({ timestamp, static_cast<double>(diag.status) });
       }
 
     }


### PR DESCRIPTION
YES, the standard committee believes this might be narrowing and clang 12 throws this error:

> error: non-constant-expression cannot be narrowed from type 'uint8_t' (aka 'unsigned char') to 'double' in initializer list [-Wc++11-narrowing]

More information [here](https://stackoverflow.com/a/11521166)