### PR TITLE
fix: galactic build

### DIFF
--- a/plugins/DataLoadROS2/dataload_ros2.cpp
+++ b/plugins/DataLoadROS2/dataload_ros2.cpp
@@ -150,7 +150,7 @@ bool DataLoadROS2::readDataFromFile(PJ::FileLoadInfo* info,
 
   if (_bag_reader)
   {
-    _bag_reader->reset();
+    _bag_reader->close();
   }
   _bag_reader = temp_bag_reader;
   //---------------------------------------

--- a/plugins/DataStreamROS2/datastream_ros2.cpp
+++ b/plugins/DataStreamROS2/datastream_ros2.cpp
@@ -21,9 +21,9 @@ DataStreamROS2::DataStreamROS2() :
   _context = std::make_shared<rclcpp::Context>();
   _context->init(0, nullptr);
 
-  auto exec_args = rclcpp::executor::ExecutorArgs();
-  exec_args.context = _context;
-  _executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>(exec_args, 2);
+  auto exec_opts = rclcpp::ExecutorOptions();
+  exec_opts.context = _context;
+  _executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>(exec_opts, 2);
 
 }
 

--- a/plugins/DataStreamROS2/rosbag2_helper.hpp
+++ b/plugins/DataStreamROS2/rosbag2_helper.hpp
@@ -39,7 +39,7 @@ inline rclcpp::QoS adapt_request_to_offers(
     request_qos.reliable();
   } else {
     if (reliability_reliable_endpoints_count > 0) {
-      ROSBAG2_TRANSPORT_LOG_WARN_STREAM( topic_name <<
+      RCLCPP_WARN_STREAM(rclcpp::get_logger("plotjuggler_ros"), topic_name <<
           ": some, but not all, publishers on topic "
           "are offering RMW_QOS_POLICY_RELIABILITY_RELIABLE. "
           "Falling back to RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT "
@@ -55,7 +55,7 @@ inline rclcpp::QoS adapt_request_to_offers(
     request_qos.transient_local();
   } else {
     if (durability_transient_local_endpoints_count > 0) {
-      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(topic_name <<
+      RCLCPP_WARN_STREAM(rclcpp::get_logger("plotjuggler_ros"), topic_name <<
           ": some, but not all, publishers on topic "
           "are offering RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL. "
           "Falling back to RMW_QOS_POLICY_DURABILITY_VOLATILE "

--- a/plugins/TopicPublisherROS2/publisher_ros2.cpp
+++ b/plugins/TopicPublisherROS2/publisher_ros2.cpp
@@ -25,9 +25,9 @@ TopicPublisherROS2::TopicPublisherROS2() :  _node(nullptr), _enabled(false)
   _context = std::make_shared<rclcpp::Context>();
   _context->init(0, nullptr);
 
-  auto exec_args = rclcpp::executor::ExecutorArgs();
-  exec_args.context = _context;
-  _executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>(exec_args, 2);
+  auto exec_opts = rclcpp::ExecutorOptions();
+  exec_opts.context = _context;
+  _executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>(exec_opts, 2);
 
   _select_topics_to_publish = new QAction(QString("Select topics to be published"));
   connect(_select_topics_to_publish, &QAction::triggered,

--- a/plugins/ros2_parsers/generic_subscription.hpp
+++ b/plugins/ros2_parsers/generic_subscription.hpp
@@ -23,7 +23,6 @@
 #include "rclcpp/subscription.hpp"
 #include "rclcpp/any_subscription_callback.hpp"
 #include "rclcpp/subscription.hpp"
-#include "rosbag2_transport/logging.hpp"
 
 namespace rosbag2_transport
 {


### PR DESCRIPTION
plotjuggler_ros is once removed from galactic due to the regression test.
https://discourse.ros.org/t/new-packages-for-galactic-geochelone-2022-03-14/24688
This fixes the build failure on galactic.
