### PR TITLE
Introduce environment variables to skip dialogs to automate PlotJuggler usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ ROS is supported through external plugins that can be found in this [repository]
 - **Logs/rosout** visualizer (ROS only).
 - **Re-publisher** similar to `rosbag play` (ROS only).
 
+## Skip the topic selection window (useful when loading a layout)
+When loading a layout that includes ROS topics, PlotJuggler shows the ROS topic selection dialog, in order to skip
+clicking on `Ok` you can set the environment variable: `PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG=1` and this dialog will be skipped.
+
+Note that if you click on `Stop` and then on `Start` again, you will be able to edit the topics.
+
 
 ## Install with Debians (TODO)
 

--- a/plugins/DataStreamROS/datastream_ROS.cpp
+++ b/plugins/DataStreamROS/datastream_ROS.cpp
@@ -374,7 +374,19 @@ bool DataStreamROS::start(QStringList* selected_datasources)
     dialog.updateTopicList(all_topics);
   });
 
-  int res = dialog.exec();
+  const char* env_var = std::getenv("PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG");
+  bool skip_topics_dialog_box = (env_var != nullptr && env_var[0] == '1');
+  int res = QDialog::Accepted;
+  if(skip_topics_dialog_box){
+    qDebug() << "Environment variable PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG set. Skipping dialog.\n";
+    // To enable the user to choose topics manually in the future
+    setenv("PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG", "0", 1);
+    dialog.on_buttonBox_accepted();
+  }
+  else{
+    res = dialog.exec();
+  }
+
   _config = dialog.getResult();
   timer.stop();
 

--- a/plugins/DataStreamROS2/datastream_ros2.cpp
+++ b/plugins/DataStreamROS2/datastream_ros2.cpp
@@ -103,7 +103,19 @@ bool DataStreamROS2::start(QStringList* selected_datasources)
 
   connect(&update_list_timer, &QTimer::timeout, getTopicsFromNode);
 
-  int res = dialog.exec();
+  const char* env_var = std::getenv("PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG");
+  bool skip_topics_dialog_box = (env_var != nullptr && env_var[0] == '1');
+  int res = QDialog::Accepted;
+  if(skip_topics_dialog_box){
+    qDebug() << "Environment variable PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG set. Skipping dialog.\n";
+    // To enable the user to choose topics manually in the future
+    setenv("PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG", "0", 1);
+    dialog.on_buttonBox_accepted();
+  }
+  else{
+    res = dialog.exec();
+  }
+  
   _config = dialog.getResult();
   update_list_timer.stop();
 

--- a/plugins/dialog_select_ros_topics.h
+++ b/plugins/dialog_select_ros_topics.h
@@ -33,9 +33,9 @@ public slots:
 
   void updateTopicList(std::vector<std::pair<QString, QString>> topic_list);
 
-private slots:
-
   void on_buttonBox_accepted();
+
+private slots:
 
   void on_listRosTopics_itemSelectionChanged();
 


### PR DESCRIPTION
Introducing the environment variable:
`PLOTJUGGLER_ACCEPT_SELECT_ROS_TOPIC_DIALOG=1` to skip the ROS topic selection dialog. 
Note that there is a sibling PR (https://github.com/facontidavide/PlotJuggler/pull/811) in PlotJuggler to skip other dialogs.

This is a workaround for https://github.com/facontidavide/PlotJuggler/issues/201 (passing commandline flags would require a lot of changes).

P.S.: I would have loved to pass it via commandline, but from the plugin side, I am not sure how I would pass down the flags all the way to the plugin in an elegant way. Using environment variables is not great, but it works.
P.S.2: I do not expect this to be merged due to the lack of elegance. But maybe people will want it enough to build from source. (I may).