### PR TITLE
Enable pal_statistics plugin for ROS 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if( CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)
         nav_msgs
         sensor_msgs
         plotjuggler_msgs
-       #  pal_statistics_msgs
+        pal_statistics_msgs
         plotjuggler )
 
     find_package(catkin REQUIRED COMPONENTS ${ROS_DEPENDENCIES} )
@@ -50,7 +50,7 @@ elseif( DEFINED ENV{AMENT_PREFIX_PATH})
     find_package(tf2_msgs REQUIRED)
     find_package(tf2_ros REQUIRED)
     find_package(plotjuggler REQUIRED)
-   #  find_package(pal_statistics_msgs REQUIRED)
+    find_package(pal_statistics_msgs REQUIRED)
 
 else()
     message(FATAL_ERROR "PlotJuggler is being WITHOUT any ROS support")

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -94,7 +94,7 @@ elseif(COMPILING_WITH_AMENT)
         nav_msgs
         diagnostic_msgs
         plotjuggler_msgs
-     #    pal_statistics_msgs
+        pal_statistics_msgs
         tf2_msgs
         tf2_ros
         plotjuggler

--- a/plugins/ros2_parsers/ros2_parser.cpp
+++ b/plugins/ros2_parsers/ros2_parser.cpp
@@ -6,7 +6,7 @@
 #include "plotjuggler_msgs.h"
 #include "diagnostic_msg.h"
 #include "pj_statistics_msg.h"
-//  #include "pal_statistics_msg.h"
+#include "pal_statistics_msg.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string.hpp>
@@ -160,14 +160,14 @@ void Ros2CompositeParser::registerMessageType(const std::string& topic_name,
   {
     parser.reset(new PJ_StatisticsValuesParser(topic_name, _plot_data));
   }
-//  else if (type == "pal_statistics_msgs/StatisticsNames")
-//  {
-//    parser.reset(new PAL_StatisticsNamesParser(topic_name, _plot_data));
-//  }
-//  else if (type == "pal_statistics_msgs/StatisticsValues")
-//  {
-//    parser.reset(new PAL_StatisticsValuesParser(topic_name, _plot_data));
-//  }
+  else if (type == "pal_statistics_msgs/StatisticsNames")
+  {
+    parser.reset(new PAL_StatisticsNamesParser(topic_name, _plot_data));
+  }
+  else if (type == "pal_statistics_msgs/StatisticsValues")
+  {
+    parser.reset(new PAL_StatisticsValuesParser(topic_name, _plot_data));
+  }
   else
   {
     parser.reset(new IntrospectionParser(topic_name, type, _plot_data));


### PR DESCRIPTION
Hi,

This PR enables the`pal_statistics` plugin for ROS 2.

Plotjuggler with the `pal_statistics` plugin disabled:
![pal-statistics-disabled-names](https://github.com/PlotJuggler/plotjuggler-ros-plugins/assets/48183611/54f6683f-d542-4701-b541-66c49ce809b6)
![pal-statistics-disabled-values](https://github.com/PlotJuggler/plotjuggler-ros-plugins/assets/48183611/eb8293a0-8852-4d68-9494-bfd69f4d4455)

Plotjuggler with the changes of this PR, i.e. `pal_statistics` plugin enabled:
![pal-statistics-enabled](https://github.com/PlotJuggler/plotjuggler-ros-plugins/assets/48183611/5d384218-c800-45fd-86da-032ed6dd2da2)
