### PR TITLE
Compilation fix for C++ 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# VIM temporary files
+*.un~

--- a/plugins/ros1_introspection/src/ros_message.cpp
+++ b/plugins/ros1_introspection/src/ros_message.cpp
@@ -59,7 +59,9 @@ ROSMessage::ROSMessage(const std::string& msg_def)
     }
 
     // Trim start of line
-    line.erase(line.begin(), std::find_if(line.begin(), line.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+    //line.erase(line.begin(), std::find_if(line.begin(), line.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+    line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](unsigned char c){return !std::isspace(c);}));
+
 
     if (line.compare(0, 5, "MSG: ") == 0)
     {


### PR DESCRIPTION
std::ptr_fun was depreciated in C++11 and and removed in C++17. It leads to an error while compiling this from the source.

Refer to issue #69 for specific error message.