### PR TITLE
Changes type of strings_chain to std::vector

### DIFF
--- a/plugins/ros1_introspection/src/stringtree_leaf.cpp
+++ b/plugins/ros1_introspection/src/stringtree_leaf.cpp
@@ -90,7 +90,7 @@ void CreateStringFromTreeLeaf(const StringTreeLeaf& leaf, bool skip_root, std::s
     return;
   }
 
-  boost::container::static_vector<const std::string*, 16> strings_chain;
+  std::vector<const std::string*> strings_chain;
 
   size_t total_size = 0;
 


### PR DESCRIPTION
Change type of strings_chain in stringree_leaf.cpp from boost::container::static_vector of fixed size 16 to std::vector to support arbitrary depth of messages