### PR TITLE
Add support for compressed rosbags

### DIFF
--- a/src/DataLoadROS2/dataload_ros2.cpp
+++ b/src/DataLoadROS2/dataload_ros2.cpp
@@ -27,6 +27,7 @@
 #include "ros_parsers/ros2_parser.h"
 
 #include <rosbag2_storage/storage_options.hpp>
+#include <rosbag2_transport/reader_writer_factory.hpp>
 
 DataLoadROS2::DataLoadROS2()
 {
@@ -44,8 +45,6 @@ bool DataLoadROS2::readDataFromFile(PJ::FileLoadInfo* info,
 {
   auto metadata_io = std::make_unique<rosbag2_storage::MetadataIo>();
 
-  auto temp_bag_reader = std::make_shared<rosbag2_cpp::readers::SequentialReader>();
-
   QString bagDir;
   {
     QFileInfo finfo(info->filename);
@@ -59,6 +58,9 @@ bool DataLoadROS2::readDataFromFile(PJ::FileLoadInfo* info,
   rosbag2_cpp::ConverterOptions converterOptions;
   converterOptions.input_serialization_format = "cdr";
   converterOptions.output_serialization_format = rmw_get_serialization_format();
+
+  std::shared_ptr<rosbag2_cpp::Reader> temp_bag_reader =
+      rosbag2_transport::ReaderWriterFactory::make_reader(storageOptions);
 
   QString oldPath = QDir::currentPath();
   QDir::setCurrent(QDir::cleanPath(bagDir + QDir::separator() + ".."));

--- a/src/DataLoadROS2/dataload_ros2.h
+++ b/src/DataLoadROS2/dataload_ros2.h
@@ -5,7 +5,7 @@
 #include <QtPlugin>
 #include <QSettings>
 
-#include <rosbag2_cpp/readers/sequential_reader.hpp>
+#include <rosbag2_cpp/reader.hpp>
 #include <PlotJuggler/dataloader_base.h>
 #include "dialog_select_ros_topics.h"
 #include "parser_configuration.h"
@@ -36,7 +36,7 @@ public:
   virtual bool xmlLoadState(const QDomElement& parent_element) override;
 
 private:
-  std::shared_ptr<rosbag2_cpp::readers::SequentialReader> _bag_reader;
+  std::shared_ptr<rosbag2_cpp::Reader> _bag_reader;
 
   std::vector<const char*> _extensions;
 


### PR DESCRIPTION
This adds support for compressed bags using the `make_reader` factory function from rosbag2_transport.

Tested using ROS humble and iron using Plotjuggler v3.8.5

Test rosbags: [test_rosbags.zip](https://github.com/PlotJuggler/plotjuggler-ros-plugins/files/13832013/test_rosbags.zip)
