### PR TITLE
Fix detection of ROS 2 Humble

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
     <!-- ROS2 dependencies -->
     <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
+    <depend condition="$ROS_VERSION == 2">ros_environment</depend>
     <depend condition="$ROS_VERSION == 2">rclcpp</depend>
     <depend condition="$ROS_VERSION == 2">rcpputils</depend>
     <depend condition="$ROS_VERSION == 2">rosbag2</depend>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,7 @@ elseif(COMPILING_WITH_AMENT)
     target_link_libraries( TopicPublisherROS2 commonROS)
     ament_target_dependencies( TopicPublisherROS2 ${AMENT_DEPENDENCIES})
 
-    if("$ENV{AMENT_PREFIX_PATH}" MATCHES ".*/opt/ros/humble")
+    if("$ENV{ROS_DISTRO}" STREQUAL "humble")
         message(STATUS "Detected Humble")
         target_compile_definitions(TopicPublisherROS2 PUBLIC ROS_HUMBLE)
     endif()


### PR DESCRIPTION
Detecting the ROS distribution based on the content of AMENT_PREFIX_PATH does not always work. For example, when using the Nix package manager, paths in AMENT_PREFIX_PATH could never match the currently used pattern. It's better to use ROS_DISTRO variable for this purpose. This should (I think) work everywhere.