### PR TITLE
Fix compilation: Update include path to Plotjuggler/fmt

### DIFF
--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -8,7 +8,7 @@
 
 #include <rosidl_typesupport_cpp/identifier.hpp>
 #include <rosidl_typesupport_introspection_cpp/identifier.hpp>
-#include <PlotJuggler/fmt/core.h>
+#include <PlotJuggler/contrib/fmt/core.h>
 
 
 bool TypeHasHeader(const rosidl_message_type_support_t* type_support)


### PR DESCRIPTION
Commit https://github.com/facontidavide/PlotJuggler/commit/7df5162153a18ca1d950d1718c02eca9d3f06ac8 changed the include path for fmt what breaks compilation in the plugins.

Simple fix.
