### PR TITLE
ROS2 wstring data type fix

### DIFF
--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -8,7 +8,7 @@
 
 #include <rosidl_typesupport_cpp/identifier.hpp>
 #include <rosidl_typesupport_introspection_cpp/identifier.hpp>
-#include <PlotJuggler/fmt/core.h>
+#include <PlotJuggler/contrib/fmt/core.h>
 
 
 bool TypeHasHeader(const rosidl_message_type_support_t* type_support)
@@ -72,6 +72,7 @@ std::string CreateSchema(const std::string& base_type)
         case ROS_TYPE_UINT64: schema += "uint64"; break;
         case ROS_TYPE_INT64: schema += "int64"; break;
         case ROS_TYPE_STRING: schema += "string"; break;
+        case ROS_TYPE_WSTRING: schema += "string"; break;
         case ROS_TYPE_MESSAGE: {
             auto type_info = reinterpret_cast<const MessageMembers*>(member.members_->data);
             std::string package = type_info->message_namespace_;


### PR DESCRIPTION
In the latest release 2.1.1 if your ROS2 message definition contains a `wstring` type, you get a "`Bad field when parsing field`" popup error. This PR includes wstring as a valid type for a message so that those topics can be subscribed to. In python wstring is treated the exact same as a normal string, and in c++ wstring is a `u16string`.

The latest base PlotJuggler 3.9.1 release also changes some import paths that make building from source fail, that import is fixed in this PR.

Testing Environment:
OS: Ubuntu 22.04
ROS2 Rolling as of 04/16/2024
PlotJuggler and ros_msg and plugin latest source as of 04/16/2024
FastDDS (rolling default)