### PR TITLE
Keep humble compatibility with send_timestamp in dataload_ros2.cpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ elseif(COMPILING_WITH_AMENT)
 
     if("$ENV{ROS_DISTRO}" STREQUAL "humble")
         message(STATUS "Detected Humble")
+        target_compile_definitions(DataLoadROS2 PUBLIC ROS_HUMBLE)
         target_compile_definitions(TopicPublisherROS2 PUBLIC ROS_HUMBLE)
     endif()
 endif()

--- a/src/DataLoadROS2/dataload_ros2.cpp
+++ b/src/DataLoadROS2/dataload_ros2.cpp
@@ -193,7 +193,7 @@ bool DataLoadROS2::readDataFromFile(PJ::FileLoadInfo* info,
     {
       continue;
     }
-    const double msg_timestamp = 1e-9 * double(msg->send_timestamp);  // nanoseconds to seconds
+    const double msg_timestamp = 1e-9 * double(msg->time_stamp);  // nanoseconds to seconds
 
     //------ progress dialog --------------
     if (msg_count++ % 100 == 0)

--- a/src/DataLoadROS2/dataload_ros2.cpp
+++ b/src/DataLoadROS2/dataload_ros2.cpp
@@ -193,7 +193,13 @@ bool DataLoadROS2::readDataFromFile(PJ::FileLoadInfo* info,
     {
       continue;
     }
+
+#ifdef ROS_HUMBLE
     const double msg_timestamp = 1e-9 * double(msg->time_stamp);  // nanoseconds to seconds
+#else
+    // from jazzy and later
+    const double msg_timestamp = 1e-9 * double(msg->send_timestamp);  // nanoseconds to seconds
+#endif
 
     //------ progress dialog --------------
     if (msg_count++ % 100 == 0)


### PR DESCRIPTION
- Continuation from https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/96

This aims to solve the problem without breaking the compatibility with jazzy.