### PR TITLE
Replace rosbag2_cpp typesupport helpers with rclcpp typesupport helpers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,13 +10,14 @@ QT5_WRAP_UI ( COMMON_UI_SRC
 
 
 add_library( commonROS STATIC
-   dialog_select_ros_topics.h
+    dialog_select_ros_topics.h
     dialog_select_ros_topics.cpp
     dialog_with_itemlist.h
     publisher_select_dialog.h
     parser_configuration.cpp
     parser_configuration.h
     ros_parsers/ros2_parser.cpp
+    typesupport_wrapper.cpp
     ${COMMON_UI_SRC}
 )
 
@@ -51,6 +52,7 @@ if("$ENV{ROS_DISTRO}" STREQUAL "humble")
         message(STATUS "Detected Humble")
         target_compile_definitions(DataLoadROS2 PUBLIC ROS_HUMBLE)
         target_compile_definitions(TopicPublisherROS2 PUBLIC ROS_HUMBLE)
+        target_compile_definitions(commonROS PUBLIC ROS_HUMBLE)
 endif()
 
 #######################################################################

--- a/src/DataLoadROS2/dataload_ros2.cpp
+++ b/src/DataLoadROS2/dataload_ros2.cpp
@@ -93,7 +93,6 @@ bool DataLoadROS2::readDataFromFile(PJ::FileLoadInfo* info, PJ::PlotDataMapRef& 
     all_topics_qt.push_back({ QString::fromStdString(topic.name), QString::fromStdString(topic.type) });
     topicTypesByName.emplace(topic.name, topic.type);
 
-    const auto& typesupport_identifier = rosidl_typesupport_cpp::typesupport_identifier;
     try
     {
       topics_info.emplace_back(CreateTopicInfo(topic.name, topic.type));

--- a/src/DataLoadROS2/dataload_ros2.cpp
+++ b/src/DataLoadROS2/dataload_ros2.cpp
@@ -17,7 +17,6 @@
 #include <rosidl_typesupport_introspection_cpp/message_introspection.hpp>
 #include <rosidl_typesupport_introspection_cpp/field_types.hpp>
 #include <rosidl_typesupport_cpp/identifier.hpp>
-#include <rosbag2_cpp/typesupport_helpers.hpp>
 #include <rosbag2_cpp/types/introspection_message.hpp>
 #include <unordered_map>
 #include <rclcpp/rclcpp.hpp>

--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -48,8 +48,9 @@ public:
   static std::shared_ptr<GenericPublisher> create(rclcpp::Node& node, const std::string& topic_name,
                                                   const std::string& topic_type)
   {
-    auto library = std::move(rosbag2_cpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp"));
-    auto type_support = rosbag2_cpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", library);
+  
+   auto library = std::move(rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp"));
+   auto type_support = rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *library);
 
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }

--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -50,9 +50,8 @@ public:
   static std::shared_ptr<GenericPublisher> create(rclcpp::Node& node, const std::string& topic_name,
                                                   const std::string& topic_type)
   {
-  
-   auto library = std::move(wrapper::get_typesupport_library(topic_type, "rosidl_typesupport_cpp"));
-   auto type_support = wrapper::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", library);
+    auto library = std::move(wrapper::get_typesupport_library(topic_type, "rosidl_typesupport_cpp"));
+    auto type_support = wrapper::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", library);
 
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }

--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -50,7 +50,7 @@ public:
   {
   
    auto library = std::move(rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp"));
-   auto type_support = rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *library);
+   auto type_support = rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *library);
 
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }

--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -20,6 +20,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/publisher_base.hpp>
 
+#include "typesupport_wrapper.h"
+
 class GenericPublisher : public rclcpp::PublisherBase
 {
 public:
@@ -49,8 +51,8 @@ public:
                                                   const std::string& topic_type)
   {
   
-   auto library = std::move(rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp"));
-   auto type_support = rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *library);
+   auto library = std::move(wrapper::get_typesupport_library(topic_type, "rosidl_typesupport_cpp"));
+   auto type_support = wrapper::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", library);
 
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }

--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -44,8 +44,8 @@ std::string CreateSchema(const std::string& base_type)
   auto addTypeToSchema = [&](const std::string& type_name, bool add_header)
   {
     auto introspection_library = rclcpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
-    auto introspection_support = rclcpp::get_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
-                                                                *introspection_library);
+    auto introspection_support = rclcpp::get_message_typesupport_handle(
+        type_name, "rosidl_typesupport_introspection_cpp", *introspection_library);
 
     if (add_header)
     {
@@ -148,12 +148,12 @@ TopicInfo CreateTopicInfo(const std::string& topic_name, const std::string& type
   info.type = type_name;
 
   info.introspection_library = rclcpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
-  info.introspection_support = rclcpp::get_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
-                                                              *info.introspection_library);
+  info.introspection_support = rclcpp::get_message_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
+                                                                      *info.introspection_library);
 
   auto identifier   = rosidl_typesupport_cpp::typesupport_identifier;
   info.support_library = rclcpp::get_typesupport_library(type_name, identifier);
-  info.type_support = rclcpp::get_typesupport_handle(type_name, identifier, *info.support_library);
+  info.type_support = rclcpp::get_message_typesupport_handle(type_name, identifier, *info.support_library);
 
   info.has_header_stamp = TypeHasHeader(info.introspection_support);
   return info;

--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -41,11 +41,11 @@ std::string CreateSchema(const std::string& base_type)
   std::set<std::string> secondary_types_pending;
   std::set<std::string> secondary_types_done;
 
-  auto addTypeToSchema = [&](const std::string& type_name, bool add_header) {
-    auto introspection_library =
-        rosbag2_cpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
-    auto introspection_support =
-        rosbag2_cpp::get_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp", introspection_library);
+  auto addTypeToSchema = [&](const std::string& type_name, bool add_header)
+  {
+    auto introspection_library = rclcpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
+    auto introspection_support = rclcpp::get_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
+                                                                *introspection_library);
 
     if (add_header)
     {
@@ -147,13 +147,13 @@ TopicInfo CreateTopicInfo(const std::string& topic_name, const std::string& type
   info.topic_name = topic_name;
   info.type = type_name;
 
-  info.introspection_library = rosbag2_cpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
-  info.introspection_support = rosbag2_cpp::get_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
-                                                                   info.introspection_library);
+  info.introspection_library = rclcpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
+  info.introspection_support = rclcpp::get_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
+                                                              *info.introspection_library);
 
-  auto identifier = rosidl_typesupport_cpp::typesupport_identifier;
-  info.support_library = rosbag2_cpp::get_typesupport_library(type_name, identifier);
-  info.type_support = rosbag2_cpp::get_typesupport_handle(type_name, identifier, info.support_library);
+  auto identifier   = rosidl_typesupport_cpp::typesupport_identifier;
+  info.support_library = rclcpp::get_typesupport_library(type_name, identifier);
+  info.type_support = rclcpp::get_typesupport_handle(type_name, identifier, *info.support_library);
 
   info.has_header_stamp = TypeHasHeader(info.introspection_support);
   return info;

--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -35,7 +35,6 @@ bool TypeHasHeader(const rosidl_message_type_support_t* type_support)
 std::string CreateSchema(const std::string& base_type)
 {
   std::string schema;
-  using TypeSupport = rosidl_message_type_support_t;
   using namespace rosidl_typesupport_introspection_cpp;
 
   std::set<std::string> secondary_types_pending;

--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -10,6 +10,8 @@
 #include <rosidl_typesupport_introspection_cpp/identifier.hpp>
 #include <fmt/core.h>
 
+#include "typesupport_wrapper.h"
+
 bool TypeHasHeader(const rosidl_message_type_support_t* type_support)
 {
   auto members = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers*>(type_support->data);
@@ -42,9 +44,9 @@ std::string CreateSchema(const std::string& base_type)
 
   auto addTypeToSchema = [&](const std::string& type_name, bool add_header)
   {
-    auto introspection_library = rclcpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
-    auto introspection_support = rclcpp::get_message_typesupport_handle(
-        type_name, "rosidl_typesupport_introspection_cpp", *introspection_library);
+    auto introspection_library = wrapper::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
+    auto introspection_support = wrapper::get_message_typesupport_handle(
+        type_name, "rosidl_typesupport_introspection_cpp", introspection_library);
 
     if (add_header)
     {
@@ -146,13 +148,13 @@ TopicInfo CreateTopicInfo(const std::string& topic_name, const std::string& type
   info.topic_name = topic_name;
   info.type = type_name;
 
-  info.introspection_library = rclcpp::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
-  info.introspection_support = rclcpp::get_message_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
-                                                                      *info.introspection_library);
+  info.introspection_library = wrapper::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
+  info.introspection_support = wrapper::get_message_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
+                                                                       info.introspection_library);
 
   auto identifier   = rosidl_typesupport_cpp::typesupport_identifier;
-  info.support_library = rclcpp::get_typesupport_library(type_name, identifier);
-  info.type_support = rclcpp::get_message_typesupport_handle(type_name, identifier, *info.support_library);
+  info.support_library = wrapper::get_typesupport_library(type_name, identifier);
+  info.type_support = wrapper::get_message_typesupport_handle(type_name, identifier, info.support_library);
 
   info.has_header_stamp = TypeHasHeader(info.introspection_support);
   return info;

--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -42,8 +42,7 @@ std::string CreateSchema(const std::string& base_type)
   std::set<std::string> secondary_types_pending;
   std::set<std::string> secondary_types_done;
 
-  auto addTypeToSchema = [&](const std::string& type_name, bool add_header)
-  {
+  auto addTypeToSchema = [&](const std::string& type_name, bool add_header) {
     auto introspection_library = wrapper::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
     auto introspection_support = wrapper::get_message_typesupport_handle(
         type_name, "rosidl_typesupport_introspection_cpp", introspection_library);
@@ -149,10 +148,10 @@ TopicInfo CreateTopicInfo(const std::string& topic_name, const std::string& type
   info.type = type_name;
 
   info.introspection_library = wrapper::get_typesupport_library(type_name, "rosidl_typesupport_introspection_cpp");
-  info.introspection_support = wrapper::get_message_typesupport_handle(type_name, "rosidl_typesupport_introspection_cpp",
-                                                                       info.introspection_library);
+  info.introspection_support = wrapper::get_message_typesupport_handle(
+      type_name, "rosidl_typesupport_introspection_cpp", info.introspection_library);
 
-  auto identifier   = rosidl_typesupport_cpp::typesupport_identifier;
+  auto identifier = rosidl_typesupport_cpp::typesupport_identifier;
   info.support_library = wrapper::get_typesupport_library(type_name, identifier);
   info.type_support = wrapper::get_message_typesupport_handle(type_name, identifier, info.support_library);
 

--- a/src/ros_parsers/ros2_parser.h
+++ b/src/ros_parsers/ros2_parser.h
@@ -3,7 +3,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rmw/rmw.h"
 #include "rmw/types.h"
-#include "rosbag2_cpp/typesupport_helpers.hpp"
+#include "rclcpp/typesupport_helpers.hpp"
 #include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
 
 #include <PlotJuggler/plotdata.h>

--- a/src/ros_parsers/ros2_parser.h
+++ b/src/ros_parsers/ros2_parser.h
@@ -3,7 +3,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rmw/rmw.h"
 #include "rmw/types.h"
-#include "rclcpp/typesupport_helpers.hpp"
 #include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
 
 #include <PlotJuggler/plotdata.h>

--- a/src/typesupport_wrapper.cpp
+++ b/src/typesupport_wrapper.cpp
@@ -4,29 +4,31 @@
 #include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
 #ifdef ROS_HUMBLE
-    #include "rosbag2_cpp/typesupport_helpers.hpp"
+#include "rosbag2_cpp/typesupport_helpers.hpp"
 #else
-    #include "rclcpp/typesupport_helpers.hpp"
+#include "rclcpp/typesupport_helpers.hpp"
 #endif
 
-namespace wrapper {
-    std::shared_ptr<rcpputils::SharedLibrary>
-            get_typesupport_library(const std::string & type, const std::string & typesupport_identifier) {
-    #ifdef ROS_HUMBLE
-        return rosbag2_cpp::get_typesupport_library(type, typesupport_identifier);
-    #else
-        return rclcpp::get_typesupport_library(type, typesupport_identifier);
-    #endif
-    }
-
-    const rosidl_message_type_support_t *
-    get_message_typesupport_handle(const std::string &type,
-                                   const std::string &typesupport_identifier,
-                                   std::shared_ptr<rcpputils::SharedLibrary> library) {
-    #ifdef ROS_HUMBLE
-        return rosbag2_cpp::get_typesupport_handle(type, typesupport_identifier, library);
-    #else
-        return rclcpp::get_message_typesupport_handle(type, typesupport_identifier, *library);
-    #endif
-    }
+namespace wrapper
+{
+std::shared_ptr<rcpputils::SharedLibrary> get_typesupport_library(const std::string& type,
+                                                                  const std::string& typesupport_identifier)
+{
+#ifdef ROS_HUMBLE
+  return rosbag2_cpp::get_typesupport_library(type, typesupport_identifier);
+#else
+  return rclcpp::get_typesupport_library(type, typesupport_identifier);
+#endif
 }
+
+const rosidl_message_type_support_t* get_message_typesupport_handle(const std::string& type,
+                                                                    const std::string& typesupport_identifier,
+                                                                    std::shared_ptr<rcpputils::SharedLibrary> library)
+{
+#ifdef ROS_HUMBLE
+  return rosbag2_cpp::get_typesupport_handle(type, typesupport_identifier, library);
+#else
+  return rclcpp::get_message_typesupport_handle(type, typesupport_identifier, *library);
+#endif
+}
+}  // namespace wrapper

--- a/src/typesupport_wrapper.cpp
+++ b/src/typesupport_wrapper.cpp
@@ -1,0 +1,32 @@
+
+
+#include "typesupport_wrapper.h"
+#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
+
+#ifdef ROS_HUMBLE
+    #include "rosbag2_cpp/typesupport_helpers.hpp"
+#else
+    #include "rclcpp/typesupport_helpers.hpp"
+#endif
+
+namespace wrapper {
+    std::shared_ptr<rcpputils::SharedLibrary>
+            get_typesupport_library(const std::string & type, const std::string & typesupport_identifier) {
+    #ifdef ROS_HUMBLE
+        return rosbag2_cpp::get_typesupport_library(type, typesupport_identifier);
+    #else
+        return rclcpp::get_typesupport_library(type, typesupport_identifier);
+    #endif
+    }
+
+    const rosidl_message_type_support_t *
+    get_message_typesupport_handle(const std::string &type,
+                                   const std::string &typesupport_identifier,
+                                   std::shared_ptr<rcpputils::SharedLibrary> library) {
+    #ifdef ROS_HUMBLE
+        return rosbag2_cpp::get_typesupport_handle(type, typesupport_identifier, library);
+    #else
+        return rclcpp::get_message_typesupport_handle(type, typesupport_identifier, *library);
+    #endif
+    }
+}

--- a/src/typesupport_wrapper.h
+++ b/src/typesupport_wrapper.h
@@ -1,0 +1,23 @@
+/*
+ * Wrappers to keep compatibility with all active ROS versions as of 01/2026 (Kilted, Jazzy, Humble). Dropping of
+ * this file should be reevaluated once Humble goes end of life (07/2027).
+ */
+
+#ifndef TYPESUPPORT_WRAPPER_H
+#define TYPESUPPORT_WRAPPER_H
+
+#include <memory>
+#include "rcpputils/shared_library.hpp"
+#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
+
+namespace wrapper {
+    std::shared_ptr<rcpputils::SharedLibrary>
+    get_typesupport_library(const std::string & type, const std::string & typesupport_identifier);
+
+    const rosidl_message_type_support_t *
+    get_message_typesupport_handle(const std::string &type,
+                                   const std::string &typesupport_identifier,
+                                   std::shared_ptr<rcpputils::SharedLibrary> library);
+}
+
+#endif //TYPESUPPORT_WRAPPER_H

--- a/src/typesupport_wrapper.h
+++ b/src/typesupport_wrapper.h
@@ -10,14 +10,14 @@
 #include "rcpputils/shared_library.hpp"
 #include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
-namespace wrapper {
-    std::shared_ptr<rcpputils::SharedLibrary>
-    get_typesupport_library(const std::string & type, const std::string & typesupport_identifier);
+namespace wrapper
+{
+std::shared_ptr<rcpputils::SharedLibrary> get_typesupport_library(const std::string& type,
+                                                                  const std::string& typesupport_identifier);
 
-    const rosidl_message_type_support_t *
-    get_message_typesupport_handle(const std::string &type,
-                                   const std::string &typesupport_identifier,
-                                   std::shared_ptr<rcpputils::SharedLibrary> library);
-}
+const rosidl_message_type_support_t* get_message_typesupport_handle(const std::string& type,
+                                                                    const std::string& typesupport_identifier,
+                                                                    std::shared_ptr<rcpputils::SharedLibrary> library);
+}  // namespace wrapper
 
-#endif //TYPESUPPORT_WRAPPER_H
+#endif  // TYPESUPPORT_WRAPPER_H


### PR DESCRIPTION
Hey @facontidavide ,

first of all thanks for making such an amazing tool availabe as open source! 

While trying to update a docker image for Jazzy, I stumbled upon an issue that the plotjuggler ros plugins currently do not build against the current jazzy branch.
More specifically, [this backported commit](https://github.com/ros2/rosbag2/commit/c90b88dff5e55f2ea87a8db987d2a0566cd5492c) removed the typesupport helpers header from rosbag2_cpp. Consequently, I replaced them the same way they did it in the rosbag repository (with their rclcpp equivalent).

I solely tested this against Jazzy as that is the only version I am currently using , but given it is a backported commit I assume rolling to face the same problem. Not sure about older versions.