### PR TITLE
Fix O(n^2) complexity in ROS2 topic selection dialog.

### DIFF
--- a/src/DataStreamROS2/datastream_ros2.cpp
+++ b/src/DataStreamROS2/datastream_ros2.cpp
@@ -134,8 +134,8 @@ bool DataStreamROS2::start(QStringList* selected_datasources)
       auto topic_name = QString::fromStdString(topic.first);
       auto type_name = QString::fromStdString(topic.second[0]);
       dialog_topics.push_back({ topic_name, type_name });
-      dialog.updateTopicList(dialog_topics);
     }
+    dialog.updateTopicList(dialog_topics);
   };
 
   getTopicsFromNode();


### PR DESCRIPTION
There is O(n^2) complexity due to nested loops on the list of topics in a dialog box for selecting ROS topics in the current implementation. With 500 topics (as in Autoware.Auto) the dialog box works really slow even on a very fast PC.

This PR moves updating the list of topic on UI (which has internal loop) after the loop which prepares the list, reducing complexity to O(n).

