### PR TITLE
Depend on ros_environment for Humble detection

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
     <!-- ROS2 dependencies -->
     <buildtool_depend>ament_cmake</buildtool_depend>
 
+    <depend>ros_environment</depend>
     <depend>rclcpp</depend>
     <depend>rcpputils</depend>
     <depend>rosbag2_transport</depend>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries( TopicPublisherROS2 commonROS)
 message("AMENT_PREFIX_PATH = ${AMENT_PREFIX_PATH}")
 message("ROS_DISTRO (env) = $ENV{ROS_DISTRO}")
 
-if("${AMENT_PREFIX_PATH}" STREQUAL "/opt/ros/humble" OR "$ENV{ROS_DISTRO}" STREQUAL "humble")
+if("$ENV{ROS_DISTRO}" STREQUAL "humble")
         message(STATUS "Detected Humble")
         target_compile_definitions(DataLoadROS2 PUBLIC ROS_HUMBLE)
         target_compile_definitions(TopicPublisherROS2 PUBLIC ROS_HUMBLE)


### PR DESCRIPTION
PR #98 mistakenly removed `ros_environment` from `package.xml`. This broke Humble detection, which had to be worked around in 9b03f97 ("try detecting Humble in the build farm", 2025-06-10).

This PR adds `ros_environment` dependency back and removes the Humble detection workaround.

This also helps with building the package using the Nix package manager.