### PR TITLE
fix: segfault in Topic Re-Publisher on Jazzy (uninitialized callbacks_ in GenericPublisher)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,25 @@
 Changelog for package plotjuggler_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* fix CI
+* fail to compile
+* fix
+* add pre-commit step
+* new formatting rules
+* add formatting consistent with plotjuggler App
+* Fix O(n^2) complexity in ROS2 topic selection dialog. (`#106 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/106>`_)
+* Depend on ros_environment for Humble detection (`#107 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/107>`_)
+  PR `#98 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/98>`_ mistakenly removed ros_environment from package.xml. This broke
+  Humble detection, which had to be worked around in 9b03f97 ("try
+  detecting Humble in the build farm", 2025-06-10).
+  This PR adds ros_environment dependency back and removes the Humble
+  detection workaround.
+  This also helps with building the package using the Nix package
+  manager.
+* Contributors: Davide Faconti, Michal Sojka, ksuszka
+
 2.2.0 (2025-05-21)
 ------------------
 * jazzy+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package plotjuggler_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.3.2 (2025-12-21)
+------------------
 * fix CI
 * fail to compile
 * fix

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>plotjuggler_ros</name>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <description>PlotJuggler plugin for ROS</description>
 
     <maintainer email="davide.faconti@gmail.com">Davide Faconti</maintainer>

--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -28,7 +28,8 @@ public:
 #ifdef ROS_HUMBLE
     : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options())
 #else
-    : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options(), callbacks_, true)
+    : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options(),
+                            rclcpp::PublisherEventCallbacks{}, true)
 #endif
   {
   }
@@ -53,10 +54,6 @@ public:
 
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }
-
-#ifndef ROS_HUMBLE
-  rclcpp::PublisherEventCallbacks callbacks_;
-#endif
 };
 
 #endif  // GENERIC_PUBLISHER_H

--- a/src/TopicPublisherROS2/publisher_ros2.cpp
+++ b/src/TopicPublisherROS2/publisher_ros2.cpp
@@ -14,6 +14,7 @@
 #include <QRadioButton>
 #include <unordered_map>
 #include <QMessageBox>
+#include <algorithm>
 #include <tf2_ros/qos.hpp>
 #include <rosbag2_cpp/types.hpp>
 #include <rmw/rmw.h>
@@ -153,7 +154,7 @@ void TopicPublisherROS2::filterDialog()
 
   std::map<std::string, QCheckBox*> checkbox;
 
-  for (const TopicInfo& info : _topics_info)
+  for (const TopicInfo& info : sorted_topics)
   {
     const std::string topic_name = info.topic_name;
     auto cb = new QCheckBox(dialog);


### PR DESCRIPTION
## Summary

- Fixes a segmentation fault in the ROS2 Topic Re-Publisher plugin when used with ROS2 Jazzy (#112)
- Root cause: `callbacks_` (a member of `GenericPublisher`) was passed to the `rclcpp::PublisherBase` base class constructor **before** it was initialized — C++ undefined behavior
- In Jazzy, `rclcpp::PublisherBase` calls `rclcpp::JumpHandler::JumpHandler` during construction while processing the callbacks, which dereferences the uninitialized object and causes a segfault
- Fix: replace `callbacks_` with a default-constructed temporary `rclcpp::PublisherEventCallbacks{}` and remove the now-unused member

## Test plan

- [ ] CI passes on ROS2 Jazzy build
- [ ] CI passes on ROS2 Humble build (no regression)
- [ ] CI passes on ROS2 Rolling build

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)