### PR TITLE
fix: detect rclcpp API differences via RCLCPP_VERSION_GTE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![ros2](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros2.yaml/badge.svg)](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros2.yaml)
+[![ROS2 Humble](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros-humble.yaml/badge.svg)](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros-humble.yaml)
+[![ROS2 Jazzy](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros-jazzy.yaml/badge.svg)](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros-jazzy.yaml)
+[![ROS2 Rolling](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros-rolling.yaml/badge.svg)](https://github.com/PlotJuggler/plotjuggler-ros-plugins/actions/workflows/ros-rolling.yaml)
 
 # ROS plugins for PlotJuggler
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,15 +45,6 @@ target_link_libraries( DataStreamROS2  commonROS)
 add_library( TopicPublisherROS2 SHARED TopicPublisherROS2/publisher_ros2.cpp)
 target_link_libraries( TopicPublisherROS2 commonROS)
 
-# rclcpp < 17 corresponds to Humble; newer distros expose the renamed
-# typesupport helpers and rosbag2 message fields used in the #else branches.
-if(rclcpp_VERSION VERSION_LESS "17")
-        message(STATUS "Detected Humble (rclcpp ${rclcpp_VERSION})")
-        target_compile_definitions(DataLoadROS2 PUBLIC ROS_HUMBLE)
-        target_compile_definitions(TopicPublisherROS2 PUBLIC ROS_HUMBLE)
-        target_compile_definitions(commonROS PUBLIC ROS_HUMBLE)
-endif()
-
 #######################################################################
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,11 +45,10 @@ target_link_libraries( DataStreamROS2  commonROS)
 add_library( TopicPublisherROS2 SHARED TopicPublisherROS2/publisher_ros2.cpp)
 target_link_libraries( TopicPublisherROS2 commonROS)
 
-message("AMENT_PREFIX_PATH = ${AMENT_PREFIX_PATH}")
-message("ROS_DISTRO (env) = $ENV{ROS_DISTRO}")
-
-if("$ENV{ROS_DISTRO}" STREQUAL "humble")
-        message(STATUS "Detected Humble")
+# rclcpp < 17 corresponds to Humble; newer distros expose the renamed
+# typesupport helpers and rosbag2 message fields used in the #else branches.
+if(rclcpp_VERSION VERSION_LESS "17")
+        message(STATUS "Detected Humble (rclcpp ${rclcpp_VERSION})")
         target_compile_definitions(DataLoadROS2 PUBLIC ROS_HUMBLE)
         target_compile_definitions(TopicPublisherROS2 PUBLIC ROS_HUMBLE)
         target_compile_definitions(commonROS PUBLIC ROS_HUMBLE)

--- a/src/DataLoadROS2/dataload_ros2.cpp
+++ b/src/DataLoadROS2/dataload_ros2.cpp
@@ -20,6 +20,7 @@
 #include <rosbag2_cpp/types/introspection_message.hpp>
 #include <unordered_map>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
 #include <rmw/rmw.h>
 
 #include "dialog_select_ros_topics.h"
@@ -188,11 +189,12 @@ bool DataLoadROS2::readDataFromFile(PJ::FileLoadInfo* info, PJ::PlotDataMapRef& 
       continue;
     }
 
-#ifdef ROS_HUMBLE
-    const double msg_timestamp = 1e-9 * double(msg->time_stamp);  // nanoseconds to seconds
-#else
-    // from jazzy and later
+    // rosbag2 split SerializedBagMessage::time_stamp into recv_timestamp /
+    // send_timestamp in Jazzy (rclcpp 28.x).
+#if RCLCPP_VERSION_GTE(28, 0, 0)
     const double msg_timestamp = 1e-9 * double(msg->send_timestamp);  // nanoseconds to seconds
+#else
+    const double msg_timestamp = 1e-9 * double(msg->time_stamp);  // nanoseconds to seconds
 #endif
 
     //------ progress dialog --------------

--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/publisher_base.hpp>
+#include <rclcpp/version.h>
 
 #include "typesupport_wrapper.h"
 
@@ -27,10 +28,11 @@ class GenericPublisher : public rclcpp::PublisherBase
 public:
   GenericPublisher(rclcpp::node_interfaces::NodeBaseInterface* node_base, const std::string& topic_name,
                    const rosidl_message_type_support_t& type_support)
-#ifdef ROS_HUMBLE
-    : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options())
-#else
+  // The rclcpp::PublisherBase constructor grew event-callback parameters after Humble (rclcpp 16.x).
+#if RCLCPP_VERSION_GTE(17, 0, 0)
     : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options(), callbacks_, true)
+#else
+    : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options())
 #endif
   {
   }
@@ -56,7 +58,7 @@ public:
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }
 
-#ifndef ROS_HUMBLE
+#if RCLCPP_VERSION_GTE(17, 0, 0)
   rclcpp::PublisherEventCallbacks callbacks_;
 #endif
 };

--- a/src/typesupport_wrapper.cpp
+++ b/src/typesupport_wrapper.cpp
@@ -1,34 +1,27 @@
-
-
 #include "typesupport_wrapper.h"
-#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
-#ifdef ROS_HUMBLE
-#include "rosbag2_cpp/typesupport_helpers.hpp"
-#else
 #include "rclcpp/typesupport_helpers.hpp"
-#endif
+#include "rclcpp/version.h"
+#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
 namespace wrapper
 {
 std::shared_ptr<rcpputils::SharedLibrary> get_typesupport_library(const std::string& type,
                                                                   const std::string& typesupport_identifier)
 {
-#ifdef ROS_HUMBLE
-  return rosbag2_cpp::get_typesupport_library(type, typesupport_identifier);
-#else
   return rclcpp::get_typesupport_library(type, typesupport_identifier);
-#endif
 }
 
 const rosidl_message_type_support_t* get_message_typesupport_handle(const std::string& type,
                                                                     const std::string& typesupport_identifier,
                                                                     std::shared_ptr<rcpputils::SharedLibrary> library)
 {
-#ifdef ROS_HUMBLE
-  return rosbag2_cpp::get_typesupport_handle(type, typesupport_identifier, library);
-#else
+  // rclcpp::get_message_typesupport_handle was introduced in Jazzy (rclcpp 28.x).
+  // On Humble/Iron the only name available is rclcpp::get_typesupport_handle.
+#if RCLCPP_VERSION_GTE(28, 0, 0)
   return rclcpp::get_message_typesupport_handle(type, typesupport_identifier, *library);
+#else
+  return rclcpp::get_typesupport_handle(type, typesupport_identifier, *library);
 #endif
 }
 }  // namespace wrapper


### PR DESCRIPTION
## Summary

Humble CI on `main` was failing because `src/CMakeLists.txt` gated the `ROS_HUMBLE` compile flag on `$ENV{ROS_DISTRO}` STREQUAL "humble", and that check did not match under `action-ros-ci` even though the same variable printed as `humble` from an adjacent `message()` call. Without `ROS_HUMBLE`, the Jazzy+ branch (`rclcpp::get_message_typesupport_handle`) was compiled, which does not exist in rclcpp 16.x.

Replace the whole scheme with compile-time checks against `RCLCPP_VERSION_GTE(major, minor, patch)` from `<rclcpp/version.h>`. That macro is emitted by rclcpp itself via `ament_generate_version_header`, so it is the authoritative version — independent of env vars and of the invoking shell.

### Per-site thresholds

| Site | Change | Threshold |
| --- | --- | --- |
| `typesupport_wrapper.cpp` | `rclcpp::get_message_typesupport_handle` (Jazzy rename) | `>= 28,0,0` |
| `generic_publisher.h` | `rclcpp::PublisherBase` 6-arg constructor + `callbacks_` | `>= 17,0,0` |
| `dataload_ros2.cpp` | rosbag2 `SerializedBagMessage::send_timestamp` (Jazzy split) | `>= 28,0,0` |

As a side effect this also makes Iron compile — the previous layout unconditionally took the Jazzy path whenever `ROS_HUMBLE` wasn't defined.

Also drops the now-unused `rosbag2_cpp/typesupport_helpers.hpp` include (Humble's rclcpp exposes the same helper).

### Rolling CI

Rolling's failure on the original run was unrelated — `ModuleNotFoundError: No module named 'ament_package'` at CMake configure time, an intermittent `action-ros-ci@v0.4.6` flake on Ubuntu 24.04. It passed cleanly on this PR's first CI run.

### Also included

- `docs: point README CI badges at the actual workflow files` — the previous badge referenced a non-existent `ros2.yaml` workflow.

## Test plan

- [x] Local Humble build: `source /opt/ros/humble/setup.bash && colcon build --packages-select plotjuggler_ros` → success.
- [ ] CI: ROS2 Humble green on this PR.
- [ ] CI: ROS2 Jazzy / Rolling remain green (they use the `>=28` branches, unchanged behavior).