### PR TITLE
fix(ros2_parser): strip namespace suffix instead of a fixed 5 chars

### DIFF
--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -102,7 +102,15 @@ std::string CreateSchema(const std::string& base_type)
         case ROS_TYPE_MESSAGE: {
           auto type_info = reinterpret_cast<const MessageMembers*>(member.members_->data);
           std::string package = type_info->message_namespace_;
-          package = package.substr(0, package.size() - 5);  // remove "::msg"
+          for (const std::string& suffix : { "::msg", "::srv", "::action" })
+          {
+            if (package.size() >= suffix.size() &&
+                package.compare(package.size() - suffix.size(), suffix.size(), suffix) == 0)
+            {
+              package.resize(package.size() - suffix.size());
+              break;
+            }
+          }
           const std::string field_type = fmt::format("{}/{}", package, type_info->message_name_);
           schema += field_type;
           if (secondary_types_done.count(field_type) == 0)


### PR DESCRIPTION
Fixes #1060.                                                                                          
                                                                  
  `CreateSchema()` stripped a hard-coded 5 chars to remove `"::msg"` from a                             
  message's C++ namespace. That works for `::msg` and (by coincidence) `::srv`,                         
  but mangles action-generated messages whose namespace ends in `::action`                              
  (8 chars): e.g. `docking::action` became `docking::a`, and downstream lookups                         
  failed with "package not found".                                             
                                                                                                        
  Replace the fixed strip with a suffix check over the three generator                                  
  namespaces (`::msg`, `::srv`, `::action`), each stripped by its actual length.                        
  Action feedback topics now subscribe cleanly; services unchanged.