### PR TITLE
TopicPublisherROS2: fix Re-Publisher crashes (#477, #759)

### DIFF
--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -58,7 +58,6 @@ public:
 
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }
-
 };
 
 #endif  // GENERIC_PUBLISHER_H

--- a/src/TopicPublisherROS2/generic_publisher.h
+++ b/src/TopicPublisherROS2/generic_publisher.h
@@ -30,7 +30,8 @@ public:
                    const rosidl_message_type_support_t& type_support)
   // The rclcpp::PublisherBase constructor grew event-callback parameters after Humble (rclcpp 16.x).
 #if RCLCPP_VERSION_GTE(17, 0, 0)
-    : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options(), callbacks_, true)
+    : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options(),
+                            rclcpp::PublisherEventCallbacks{}, true)
 #else
     : rclcpp::PublisherBase(node_base, topic_name, type_support, rcl_publisher_get_default_options())
 #endif
@@ -58,9 +59,6 @@ public:
     return std::make_shared<GenericPublisher>(node.get_node_base_interface().get(), topic_name, *type_support);
   }
 
-#if RCLCPP_VERSION_GTE(17, 0, 0)
-  rclcpp::PublisherEventCallbacks callbacks_;
-#endif
 };
 
 #endif  // GENERIC_PUBLISHER_H

--- a/src/TopicPublisherROS2/publisher_ros2.cpp
+++ b/src/TopicPublisherROS2/publisher_ros2.cpp
@@ -111,15 +111,6 @@ void TopicPublisherROS2::setEnabled(bool to_enable)
 
     updatePublishers();
 
-    if (!_tf_broadcaster)
-    {
-      _tf_broadcaster = std::make_unique<tf2_ros::TransformBroadcaster>(*_node);
-    }
-    if (!_tf_static_broadcaster)
-    {
-      _tf_static_broadcaster = std::make_unique<tf2_ros::StaticTransformBroadcaster>(*_node);
-    }
-
     _previous_play_index = std::numeric_limits<int>::max();
   }
   else
@@ -293,10 +284,18 @@ void TopicPublisherROS2::broadcastTF(double current_time)
     }
     if (transforms_ptr == &transforms)
     {
+      if (!_tf_broadcaster)
+      {
+        _tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*_node);
+      }
       _tf_broadcaster->sendTransform(transforms_vector);
     }
     else
     {
+      if (!_tf_static_broadcaster)
+      {
+        _tf_static_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*_node);
+      }
       _tf_static_broadcaster->sendTransform(transforms_vector);
     }
   }


### PR DESCRIPTION
Fixes #477, #759.                                                                                     
                                                                  
  Two separate crashes triggered by enabling the Re-Publisher:                                          
                                                                                                        
  - `GenericPublisher` passed its `callbacks_` member by reference to                                   
    `rclcpp::PublisherBase`. Base-class init runs before member init, so                                
    rclcpp read uninitialized `std::function` memory and crashed inside 
    the `PublisherBase` ctor. Pass a temporary `PublisherEventCallbacks{}`                              
    and drop the dead member.                                             
  - `setEnabled()` eagerly created `tf2_ros` TransformBroadcaster / Static                              
    broadcaster even for bags with no `/tf` data. On Jazzy/Rolling this   
    triggers a separate tf2 QoS-override parameter-declaration crash inside                             
    rclcpp. Defer broadcaster creation to `broadcastTF()` so it only runs  
    once `/tf` or `/tf_static` actually carries data. 