### PR TITLE
Add <fmt/format.h> for fmt 11+ compatibility

### DIFF
--- a/src/ros_parsers/ros2_parser.cpp
+++ b/src/ros_parsers/ros2_parser.cpp
@@ -1,4 +1,5 @@
 #include "ros2_parser.h"
+#include <fmt/format.h>
 
 #include <set>
 


### PR DESCRIPTION
## What
fmt 11 (2024) reorganized its headers: `fmt::format` and the other formatting functions moved out of `<fmt/core.h>` into `<fmt/format.h>` (`core.h` became a lightweight base). Files that include **only** `<fmt/core.h>` and call `fmt::format(...)` fail to compile against fmt 11 / 12 with:

```
error: no member named 'format' in namespace 'fmt'
```

Homebrew now ships **fmt 12.2.0**, so this surfaces on macOS / Apple-clang builds.

## Fix
Add `#include <fmt/format.h>` to the affected file(s):
- src/ros_parsers/ros2_parser.cpp
- 

`<fmt/format.h>` provides `fmt::format` in **every** fmt release (it pulls in the base header), so this is **backward-compatible** — no minimum-fmt bump and no behaviour change on older fmt.


## Tested on
- **macOS 26** (Apple Silicon / arm64) — GitHub Actions `macos-26` runners
- **Apple clang 21.0.0** (`clang-2100.1.1.101`, target `arm64-apple-darwin25.5.0`), C++17, libc++
- **fmt 12.2.0** (Homebrew)
- Built from source in a ROS 2 (Humble / Jazzy / Kilted) workspace, CMake 4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
